### PR TITLE
Refactor Bookings Module Dependency on Availability Module

### DIFF
--- a/src/Modules/Appointments/CliniCore.Modules.Appointments.Shell/Controllers/AppointmentsController.cs
+++ b/src/Modules/Appointments/CliniCore.Modules.Appointments.Shell/Controllers/AppointmentsController.cs
@@ -40,7 +40,7 @@ public class AppointmentsController : ControllerBase
     /// Update the status of an appointment.
     /// </summary>
     /// <remarks>
-    /// Allows updating the status of an appointment (to "Completed" or "Cancelled").
+    /// Allows updating the status of an appointment (to "Completed" or "Canceled").
     /// </remarks>
     /// <param name="id">The ID of the appointment to update.</param>
     /// <param name="request">The new status for the appointment.</param>

--- a/src/Modules/Bookings/CliniCore.Modules.Bookings.Application/BookAppointment/AddBookingHandler.cs
+++ b/src/Modules/Bookings/CliniCore.Modules.Bookings.Application/BookAppointment/AddBookingHandler.cs
@@ -1,4 +1,4 @@
-﻿using CliniCore.Modules.Availability.Shared;
+﻿using CliniCore.Modules.Bookings.Application.Interfaces;
 using CliniCore.Modules.Bookings.Domain.Contracts;
 using CliniCore.Modules.Bookings.Domain.Exceptions;
 using CliniCore.Modules.Bookings.Domain.Models;
@@ -8,19 +8,19 @@ namespace CliniCore.Modules.Bookings.Application.BookAppointment;
 public class AddBookingHandler
 {
     private readonly IBookingRepository _bookingRepository;
-    private readonly IAvailabilityModuleApi _availabilityModuleApi;
+    private readonly IAvailabilityService _availabilityService;
     private readonly IClock _clock;
 
-    public AddBookingHandler(IBookingRepository bookingRepository, IAvailabilityModuleApi availabilityModuleApi, IClock clock)
+    public AddBookingHandler(IBookingRepository bookingRepository, IAvailabilityService availabilityModuleApi, IClock clock)
     {
-        _availabilityModuleApi = availabilityModuleApi;
+        _availabilityService = availabilityModuleApi;
         _clock = clock;
         _bookingRepository = bookingRepository;
     }
 
     public async Task<BookingResponse> Handle(AddBooking command)
     {
-        var slot = await _availabilityModuleApi.GetSlotByIdAsync(command.SlotId);
+        var slot = await _availabilityService.GetSlotByIdAsync(command.SlotId);
 
         if(slot.IsReserved == true)
         {

--- a/src/Modules/Bookings/CliniCore.Modules.Bookings.Application/CliniCore.Modules.Bookings.Application.csproj
+++ b/src/Modules/Bookings/CliniCore.Modules.Bookings.Application/CliniCore.Modules.Bookings.Application.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Availability\CliniCore.Modules.Availability.Shared\CliniCore.Modules.Availability.Shared.csproj" />
     <ProjectReference Include="..\CliniCore.Modules.Bookings.Domain\CliniCore.Modules.Bookings.Domain.csproj" />
   </ItemGroup>
 

--- a/src/Modules/Bookings/CliniCore.Modules.Bookings.Application/GetAvailableBookings/GetAvailableBookingsHandler.cs
+++ b/src/Modules/Bookings/CliniCore.Modules.Bookings.Application/GetAvailableBookings/GetAvailableBookingsHandler.cs
@@ -1,37 +1,19 @@
-﻿using CliniCore.Modules.Availability.Shared;
-using CliniCore.Modules.Availability.Shared.DTO;
+﻿using CliniCore.Modules.Bookings.Application.Interfaces;
 
 namespace CliniCore.Modules.Bookings.Application.GetAvailableBookings;
 public class GetAvailableBookingsHandler
 {
-    private readonly IAvailabilityModuleApi _availabilityModuleApi;
+    private readonly IAvailabilityService _availabilityService;
 
-    public GetAvailableBookingsHandler(IAvailabilityModuleApi availabilityModuleApi)
+    public GetAvailableBookingsHandler(IAvailabilityService availabilityModuleApi)
     {
-        _availabilityModuleApi = availabilityModuleApi;
+        _availabilityService = availabilityModuleApi;
     }
 
     public async Task<IEnumerable<AvailableBookingDto>> Handle()
     {
-        var slots = await _availabilityModuleApi.GetAvailableSlotsAsync();
-
-        var availableBookings = Map(slots);
+        var availableBookings = await _availabilityService.GetAvailableSlotsAsync();
 
         return availableBookings;
-    }
-
-    private IEnumerable<AvailableBookingDto> Map(IEnumerable<SlotDto> slotDtos)
-    {
-        var availableBookingsDto = slotDtos.Select(slotDto => new AvailableBookingDto()
-        {
-            Id = slotDto.Id,
-            Cost = slotDto.Cost,
-            DoctorId = slotDto.DoctorId,
-            DoctorName = slotDto.DoctorName,
-            IsReserved = slotDto.IsReserved,
-            Time = slotDto.Time,
-        });
-
-        return availableBookingsDto;
     }
 }

--- a/src/Modules/Bookings/CliniCore.Modules.Bookings.Application/Interfaces/IAvailabilityService.cs
+++ b/src/Modules/Bookings/CliniCore.Modules.Bookings.Application/Interfaces/IAvailabilityService.cs
@@ -1,0 +1,8 @@
+﻿using CliniCore.Modules.Bookings.Application.GetAvailableBookings;
+
+namespace CliniCore.Modules.Bookings.Application.Interfaces;
+public interface IAvailabilityService
+{
+    Task<IEnumerable<AvailableBookingDto>> GetAvailableSlotsAsync();
+    Task<AvailableBookingDto> GetSlotByIdAsync(Guid id);
+}

--- a/src/Modules/Bookings/CliniCore.Modules.Bookings.Infrastructure/CliniCore.Modules.Bookings.Infrastructure.csproj
+++ b/src/Modules/Bookings/CliniCore.Modules.Bookings.Infrastructure/CliniCore.Modules.Bookings.Infrastructure.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Availability\CliniCore.Modules.Availability.Shared\CliniCore.Modules.Availability.Shared.csproj" />
     <ProjectReference Include="..\CliniCore.Modules.Bookings.Application\CliniCore.Modules.Bookings.Application.csproj" />
     <ProjectReference Include="..\CliniCore.Modules.Bookings.Shared\CliniCore.Modules.Bookings.Shared.csproj" />
   </ItemGroup>

--- a/src/Modules/Bookings/CliniCore.Modules.Bookings.Infrastructure/Extensions.cs
+++ b/src/Modules/Bookings/CliniCore.Modules.Bookings.Infrastructure/Extensions.cs
@@ -1,7 +1,9 @@
-﻿using CliniCore.Modules.Bookings.Domain.Contracts;
+﻿using CliniCore.Modules.Bookings.Application.Interfaces;
+using CliniCore.Modules.Bookings.Domain.Contracts;
 using CliniCore.Modules.Bookings.Infrastructure.DAL;
 using CliniCore.Modules.Bookings.Infrastructure.DAL.Repositories;
 using CliniCore.Modules.Bookings.Infrastructure.EventPublishers;
+using CliniCore.Modules.Bookings.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,6 +16,7 @@ public static class Extensions
     {
         services.AddScoped<IBookingRepository, BookingRepository>();
         services.AddScoped<IBookingPublisher, BookingPublisher>();
+        services.AddScoped<IAvailabilityService, AvailabilityService>();
         var connectionString = configuration.GetConnectionString("Database");
 
         services.AddDbContext<BookingDbContext>(options => {

--- a/src/Modules/Bookings/CliniCore.Modules.Bookings.Infrastructure/Services/AvailabilityService.cs
+++ b/src/Modules/Bookings/CliniCore.Modules.Bookings.Infrastructure/Services/AvailabilityService.cs
@@ -1,0 +1,64 @@
+﻿using CliniCore.Modules.Availability.Shared;
+using CliniCore.Modules.Availability.Shared.DTO;
+using CliniCore.Modules.Bookings.Application.GetAvailableBookings;
+using CliniCore.Modules.Bookings.Application.Interfaces;
+
+namespace CliniCore.Modules.Bookings.Infrastructure.Services;
+internal class AvailabilityService : IAvailabilityService
+{
+    private readonly IAvailabilityModuleApi _availabilityModuleApi;
+
+    public AvailabilityService(IAvailabilityModuleApi availabilityModuleApi)
+    {
+        _availabilityModuleApi = availabilityModuleApi;
+    }
+
+    public async Task<IEnumerable<AvailableBookingDto>> GetAvailableSlotsAsync()
+    {
+        var slots = await _availabilityModuleApi.GetAvailableSlotsAsync();
+
+        var availableBookings = Map(slots);
+
+        return availableBookings;
+    }
+
+    public async Task<AvailableBookingDto> GetSlotByIdAsync(Guid id)
+    {
+        var slot = await _availabilityModuleApi.GetSlotByIdAsync(id);
+
+        var availableBooking = Map(slot);
+
+        return availableBooking;
+    }
+
+    private IEnumerable<AvailableBookingDto> Map(IEnumerable<SlotDto> slotDtos)
+    {
+        var availableBookingsDto = slotDtos.Select(slotDto => new AvailableBookingDto()
+        {
+            Id = slotDto.Id,
+            Cost = slotDto.Cost,
+            DoctorId = slotDto.DoctorId,
+            DoctorName = slotDto.DoctorName,
+            IsReserved = slotDto.IsReserved,
+            Time = slotDto.Time,
+        });
+
+        return availableBookingsDto;
+    }
+
+    private AvailableBookingDto Map(SlotDto slotDto)
+    {
+        var availableBookingDto = new AvailableBookingDto()
+        {
+            Id = slotDto.Id,
+            Cost = slotDto.Cost,
+            DoctorId = slotDto.DoctorId,
+            DoctorName = slotDto.DoctorName,
+            IsReserved = slotDto.IsReserved,
+            Time = slotDto.Time,
+        };
+
+        return availableBookingDto;
+    }
+
+}

--- a/tests/CliniCore.Tests.Bookings/Api/BookAppointmentControllerTests.cs
+++ b/tests/CliniCore.Tests.Bookings/Api/BookAppointmentControllerTests.cs
@@ -1,8 +1,8 @@
 ﻿using AutoFixture;
 using CliniCore.Modules.Availability.Business.Exceptions;
-using CliniCore.Modules.Availability.Shared;
-using CliniCore.Modules.Availability.Shared.DTO;
 using CliniCore.Modules.Bookings.Application.BookAppointment;
+using CliniCore.Modules.Bookings.Application.GetAvailableBookings;
+using CliniCore.Modules.Bookings.Application.Interfaces;
 using CliniCore.Modules.Bookings.Infrastructure.DAL;
 using CliniCore.Modules.Bookings.Infrastructure.DAL.Entities;
 using CliniCore.Tests.Shared;
@@ -19,18 +19,18 @@ public class BookAppointmentControllerTests : IClassFixture<CustomWebApplication
     private readonly CustomWebApplicationFactory _factory;
     private readonly Fixture _fixture;
     private readonly HttpClient _httpClient;
-    private readonly Mock<IAvailabilityModuleApi> _availabilityModuleApiMock;
+    private readonly Mock<IAvailabilityService> _availabilityServiceMock;
 
     public BookAppointmentControllerTests(CustomWebApplicationFactory factory)
     {
         _factory = factory;
         _fixture = new Fixture();
-        _availabilityModuleApiMock = new Mock<IAvailabilityModuleApi>();
+        _availabilityServiceMock = new Mock<IAvailabilityService>();
         _httpClient = _factory.WithWebHostBuilder(builder =>
         {
             builder.ConfigureServices(services =>
             {
-                services.AddScoped(_ => _availabilityModuleApiMock.Object);
+                services.AddScoped(_ => _availabilityServiceMock.Object);
             });
         }).CreateClient();
     }
@@ -48,10 +48,10 @@ public class BookAppointmentControllerTests : IClassFixture<CustomWebApplication
         // Arrange
         var command = _fixture.Create<AddBooking>();
 
-        var slot = _fixture.Build<SlotDto>()
+        var slot = _fixture.Build<AvailableBookingDto>()
             .With(slot => slot.IsReserved, false).Create();
 
-        _availabilityModuleApiMock
+        _availabilityServiceMock
             .Setup(api => api.GetSlotByIdAsync(command.SlotId))
             .ReturnsAsync(slot);
 
@@ -65,7 +65,7 @@ public class BookAppointmentControllerTests : IClassFixture<CustomWebApplication
 
         var booking = await TestUtils.GetFromDatabaseAsync<BookingDbContext, BookingEntity>(_factory, responseData.Id);
 
-        _availabilityModuleApiMock.Verify(api => api.GetSlotByIdAsync(command.SlotId), Times.Once);
+        _availabilityServiceMock.Verify(api => api.GetSlotByIdAsync(command.SlotId), Times.Once);
         booking.Should().NotBeNull();
     }
 
@@ -74,10 +74,10 @@ public class BookAppointmentControllerTests : IClassFixture<CustomWebApplication
     {
         // Arrange
         var command = _fixture.Create<AddBooking>();
-        var slot = _fixture.Build<SlotDto>()
+        var slot = _fixture.Build<AvailableBookingDto>()
             .With(slot => slot.IsReserved, true).Create();
 
-        _availabilityModuleApiMock
+        _availabilityServiceMock
             .Setup(api => api.GetSlotByIdAsync(command.SlotId))
             .ReturnsAsync(slot);
 
@@ -87,7 +87,7 @@ public class BookAppointmentControllerTests : IClassFixture<CustomWebApplication
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        _availabilityModuleApiMock.Verify(api => api.GetSlotByIdAsync(command.SlotId), Times.Once);
+        _availabilityServiceMock.Verify(api => api.GetSlotByIdAsync(command.SlotId), Times.Once);
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class BookAppointmentControllerTests : IClassFixture<CustomWebApplication
         // Arrange
         var command = _fixture.Create<AddBooking>();
 
-        _availabilityModuleApiMock
+        _availabilityServiceMock
             .Setup(api => api.GetSlotByIdAsync(command.SlotId))
             .ThrowsAsync(new SlotNotFoundException());
 
@@ -106,6 +106,6 @@ public class BookAppointmentControllerTests : IClassFixture<CustomWebApplication
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        _availabilityModuleApiMock.Verify(api => api.GetSlotByIdAsync(command.SlotId), Times.Once);
+        _availabilityServiceMock.Verify(api => api.GetSlotByIdAsync(command.SlotId), Times.Once);
     }
 }

--- a/tests/CliniCore.Tests.Bookings/Api/GetAvailableBookingsControllerTests .cs
+++ b/tests/CliniCore.Tests.Bookings/Api/GetAvailableBookingsControllerTests .cs
@@ -1,14 +1,12 @@
 ﻿using AutoFixture;
-using CliniCore.Modules.Availability.Shared;
-using CliniCore.Modules.Availability.Shared.DTO;
 using CliniCore.Modules.Bookings.Application.GetAvailableBookings;
+using CliniCore.Modules.Bookings.Application.Interfaces;
 using CliniCore.Tests.Shared;
 using CliniCore.Tests.Shared.Utils;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using System.Net;
-using System.Net.Http;
 using System.Net.Http.Json;
 
 namespace CliniCore.Tests.Bookings.Api;
@@ -16,7 +14,7 @@ public class GetAvailableBookingsControllerTests : IClassFixture<CustomWebApplic
 {
     private readonly CustomWebApplicationFactory _factory;
     private readonly IFixture _fixture;
-    private readonly Mock<IAvailabilityModuleApi> _availabilityModuleApiMock;
+    private readonly Mock<IAvailabilityService> _availabilityServiceMock;
     private readonly HttpClient _httpClient;
 
 
@@ -24,12 +22,12 @@ public class GetAvailableBookingsControllerTests : IClassFixture<CustomWebApplic
     {
         _factory = factory;
         _fixture = new Fixture();
-        _availabilityModuleApiMock = new Mock<IAvailabilityModuleApi>();
+        _availabilityServiceMock = new Mock<IAvailabilityService>();
         _httpClient = _factory.WithWebHostBuilder(builder =>
         {
             builder.ConfigureServices(services =>
             {
-                services.AddScoped(_ => _availabilityModuleApiMock.Object);
+                services.AddScoped(_ => _availabilityServiceMock.Object);
             });
         }).CreateClient();
     }
@@ -44,8 +42,8 @@ public class GetAvailableBookingsControllerTests : IClassFixture<CustomWebApplic
     public async Task GetAvailableBookings_ShouldReturnOkWithAvailableBookings()
     {
         // Arrange
-        var availableSlots = _fixture.CreateMany<SlotDto>(5).ToList();
-        _availabilityModuleApiMock
+        var availableSlots = _fixture.CreateMany<AvailableBookingDto>(5).ToList();
+        _availabilityServiceMock
             .Setup(api => api.GetAvailableSlotsAsync())
             .ReturnsAsync(availableSlots);
 
@@ -63,7 +61,7 @@ public class GetAvailableBookingsControllerTests : IClassFixture<CustomWebApplic
     public async Task GetAvailableBookings_ShouldReturnInternalServerError_WhenExternalCallFails()
     {
         // Arrange
-        _availabilityModuleApiMock
+        _availabilityServiceMock
             .Setup(api => api.GetAvailableSlotsAsync())
             .ThrowsAsync(new Exception("Service unavailable"));
 

--- a/tests/CliniCore.Tests.Bookings/Application/BookAppointment/AddBookingHandlerTests.cs
+++ b/tests/CliniCore.Tests.Bookings/Application/BookAppointment/AddBookingHandlerTests.cs
@@ -1,18 +1,18 @@
 ﻿using AutoFixture;
-using CliniCore.Modules.Availability.Shared.DTO;
-using CliniCore.Modules.Availability.Shared;
 using CliniCore.Modules.Bookings.Application.BookAppointment;
+using CliniCore.Modules.Bookings.Application.GetAvailableBookings;
+using CliniCore.Modules.Bookings.Application.Interfaces;
 using CliniCore.Modules.Bookings.Domain.Contracts;
 using CliniCore.Modules.Bookings.Domain.Exceptions;
-using FluentAssertions;
-using Moq;
 using CliniCore.Modules.Bookings.Domain.Models;
 using CliniCore.Shared.Time;
+using FluentAssertions;
+using Moq;
 
 namespace CliniCore.Tests.Bookings.Application.BookAppointment;
 public class AddBookingHandlerTests
 {
-    private readonly Mock<IAvailabilityModuleApi> _availabilityModuleApiMock;
+    private readonly Mock<IAvailabilityService> _availabilityServiceMock;
     private readonly Mock<IBookingRepository> _bookingRepositoryMock;
     private readonly Mock<IClock> _clockMock;
     private readonly AddBookingHandler _handler;
@@ -20,10 +20,10 @@ public class AddBookingHandlerTests
 
     public AddBookingHandlerTests()
     {
-        _availabilityModuleApiMock = new Mock<IAvailabilityModuleApi>();
+        _availabilityServiceMock = new Mock<IAvailabilityService>();
         _bookingRepositoryMock = new Mock<IBookingRepository>();
         _clockMock = new Mock<IClock>();
-        _handler = new AddBookingHandler(_bookingRepositoryMock.Object, _availabilityModuleApiMock.Object, _clockMock.Object);
+        _handler = new AddBookingHandler(_bookingRepositoryMock.Object, _availabilityServiceMock.Object, _clockMock.Object);
         _fixture = new Fixture();
     }
 
@@ -32,7 +32,7 @@ public class AddBookingHandlerTests
     {
         // Arrange
         var command = _fixture.Create<AddBooking>();
-        var slot = new SlotDto
+        var slot = new AvailableBookingDto
         {
             Id = command.SlotId,
             IsReserved = false,
@@ -42,7 +42,7 @@ public class AddBookingHandlerTests
             Cost = 200m
         };
 
-        _availabilityModuleApiMock
+        _availabilityServiceMock
             .Setup(api => api.GetSlotByIdAsync(command.SlotId))
             .ReturnsAsync(slot);
 
@@ -59,7 +59,7 @@ public class AddBookingHandlerTests
         result.Should().NotBeNull();
         result.Id.Should().Be(expectedBookingId);
 
-        _availabilityModuleApiMock.Verify(api => api.GetSlotByIdAsync(command.SlotId), Times.Once);
+        _availabilityServiceMock.Verify(api => api.GetSlotByIdAsync(command.SlotId), Times.Once);
         _bookingRepositoryMock.Verify(repo => repo.AddBooking(It.IsAny<Booking>()), Times.Once);
     }
 
@@ -68,13 +68,13 @@ public class AddBookingHandlerTests
     {
         // Arrange
         var command = _fixture.Create<AddBooking>();
-        var slot = new SlotDto
+        var slot = new AvailableBookingDto
         {
             Id = command.SlotId,
             IsReserved = true
         };
 
-        _availabilityModuleApiMock
+        _availabilityServiceMock
             .Setup(api => api.GetSlotByIdAsync(command.SlotId))
             .ReturnsAsync(slot);
 
@@ -84,7 +84,7 @@ public class AddBookingHandlerTests
         // Assert
         await act.Should().ThrowAsync<AlreadyBookedSlotException>();
 
-        _availabilityModuleApiMock.Verify(api => api.GetSlotByIdAsync(command.SlotId), Times.Once);
+        _availabilityServiceMock.Verify(api => api.GetSlotByIdAsync(command.SlotId), Times.Once);
         _bookingRepositoryMock.Verify(repo => repo.AddBooking(It.IsAny<Booking>()), Times.Never);
     }
 }

--- a/tests/CliniCore.Tests.Bookings/Application/GetAvailableBookings/GetAvailableBookingsHandlerTests.cs
+++ b/tests/CliniCore.Tests.Bookings/Application/GetAvailableBookings/GetAvailableBookingsHandlerTests.cs
@@ -1,21 +1,20 @@
 ﻿using AutoFixture;
-using CliniCore.Modules.Availability.Shared;
-using CliniCore.Modules.Availability.Shared.DTO;
 using CliniCore.Modules.Bookings.Application.GetAvailableBookings;
+using CliniCore.Modules.Bookings.Application.Interfaces;
 using FluentAssertions;
 using Moq;
 
 namespace CliniCore.Tests.Bookings.Application.GetAvailableBookings;
 public class GetAvailableBookingsHandlerTests
 {
-    private readonly Mock<IAvailabilityModuleApi> _mockAvailabilityModuleApi;
+    private readonly Mock<IAvailabilityService> _mockAvailabilityServiceMock;
     private readonly GetAvailableBookingsHandler _handler;
     private readonly IFixture _fixture;
 
     public GetAvailableBookingsHandlerTests()
     {
-        _mockAvailabilityModuleApi = new Mock<IAvailabilityModuleApi>();
-        _handler = new GetAvailableBookingsHandler(_mockAvailabilityModuleApi.Object);
+        _mockAvailabilityServiceMock = new Mock<IAvailabilityService>();
+        _handler = new GetAvailableBookingsHandler(_mockAvailabilityServiceMock.Object);
         _fixture = new Fixture();
     }
 
@@ -23,11 +22,11 @@ public class GetAvailableBookingsHandlerTests
     public async Task Handle_ShouldReturnMappedAvailableBookings()
     {
         // Arrange
-        var slots = _fixture.Build<SlotDto>()
+        var slots = _fixture.Build<AvailableBookingDto>()
                             .With(s => s.IsReserved, false)
                             .CreateMany(5);
 
-        _mockAvailabilityModuleApi
+        _mockAvailabilityServiceMock
             .Setup(api => api.GetAvailableSlotsAsync())
             .ReturnsAsync(slots);
 
@@ -38,30 +37,30 @@ public class GetAvailableBookingsHandlerTests
         result.Should().BeEquivalentTo(slots, options => options
             .ExcludingMissingMembers());
 
-        _mockAvailabilityModuleApi.Verify(api => api.GetAvailableSlotsAsync(), Times.Once);
+        _mockAvailabilityServiceMock.Verify(api => api.GetAvailableSlotsAsync(), Times.Once);
     }
 
     [Fact]
     public async Task Handle_ShouldReturnEmptyList_WhenNoAvailableSlots()
     {
         // Arrange
-        _mockAvailabilityModuleApi
+        _mockAvailabilityServiceMock
             .Setup(api => api.GetAvailableSlotsAsync())
-            .ReturnsAsync(Enumerable.Empty<SlotDto>());
+            .ReturnsAsync(Enumerable.Empty<AvailableBookingDto>());
 
         // Act
         var result = await _handler.Handle();
 
         // Assert
         result.Should().BeEmpty();
-        _mockAvailabilityModuleApi.Verify(api => api.GetAvailableSlotsAsync(), Times.Once);
+        _mockAvailabilityServiceMock.Verify(api => api.GetAvailableSlotsAsync(), Times.Once);
     }
 
     [Fact]
     public async Task Handle_ShouldThrowException_WhenAvailabilityApiThrows()
     {
         // Arrange
-        _mockAvailabilityModuleApi
+        _mockAvailabilityServiceMock
             .Setup(api => api.GetAvailableSlotsAsync())
             .ThrowsAsync(new Exception("API Error"));
 
@@ -70,6 +69,6 @@ public class GetAvailableBookingsHandlerTests
 
         // Assert
         await action.Should().ThrowAsync<Exception>().WithMessage("API Error");
-        _mockAvailabilityModuleApi.Verify(api => api.GetAvailableSlotsAsync(), Times.Once);
+        _mockAvailabilityServiceMock.Verify(api => api.GetAvailableSlotsAsync(), Times.Once);
     }
 }


### PR DESCRIPTION
This PR refactors the dependency between the Bookings module and the Availability module. It moves the dependency from the application layer to the infrastructure layer, improving modularity, maintainability, and adherence to clean architecture principles.

Changes Made

1. Created a new abstraction in the Bookings Application Layer:
   - Added IAvailabilityService to the application layer to define the required functionality provided by the Availability module.

2. Implemented the Abstraction in the Infrastructure Layer:
   - Added AvailabilityService in the infrastructure layer of the Bookings module, which composes IAvailabilityModuleApi from the Availability module.
 
3. Refactored the Application Layer:
   - Replaced direct references to IAvailabilityModuleApi in the application layer with IAvailabilityService.